### PR TITLE
Fix instruction options in programming.goggle

### DIFF
--- a/programming.goggle
+++ b/programming.goggle
@@ -4,8 +4,8 @@
 ! author: Flourst8
 
 
-$discard,$site=quora.com
-$discard,$site=w3schools.com
-$downrank,$site=geeksforgeeks.org
-$boost=5,$site=docs.python.org
-$boost=5,$site=codecademy.com
+$discard,site=quora.com
+$discard,site=w3schools.com
+$downrank,site=geeksforgeeks.org
+$boost=5,site=docs.python.org
+$boost=5,site=codecademy.com


### PR DESCRIPTION
Hi @Fourst8,

I think the following instructions are invalid because you only need one occurrence of `$` in your instruction (what comes before is the URL pattern you want to match - or empty - and what comes after is a coma-separated list of options such as `site=yyy` or `discard`/`boost`/downrank`). 